### PR TITLE
Allow setting led text indefinitely

### DIFF
--- a/MACRO_DOCS.md
+++ b/MACRO_DOCS.md
@@ -383,6 +383,7 @@ The following grammar is supported:
 ### Uncategorized commands:
 
 - `setLedTxt <time> <custom text>` will set led display to supplemented text for the given time. (Blocks for the given time.)
+    - If the given time is zero, i.e. `<time> = 0`, the led text will be set indefinitely (until the display is refreshed by other text) and this command will returns immediately (non-blocking).
 
 ### Triggering keyboard actions (pressing keys, clicking, etc.):
 

--- a/right/src/macros.c
+++ b/right/src/macros.c
@@ -1351,7 +1351,7 @@ static macro_result_t processSetLedTxtCommand(const char* arg1, const char *argE
 {
     int16_t time = parseNUM(arg1, argEnd);
     macro_result_t res = MacroResult_Finished;
-    if ((res = processDelay(time)) == MacroResult_Finished) {
+    if (time > 0 && (res = processDelay(time)) == MacroResult_Finished) {
         LedDisplay_UpdateText();
         return MacroResult_Finished;
     } else {


### PR DESCRIPTION
Currently set led text is always blocking (and resets afterward).

This PR enables setting led set indefinitely if given t <= 0