### PR TITLE
Add on-exit hook

### DIFF
--- a/MACRO_DOCS.md
+++ b/MACRO_DOCS.md
@@ -499,6 +499,23 @@ We allow postponing key activations in order to allow deciding between some scen
   - `arg4 - adr1` index of macro action to go to if the `arg1`th next key's hardware identifier equals `arg2`.
   - `arg5 - adr2` index of macro action to go to otherwise.
 - `resolveNextKeyId` will wait for next key press. When the next key is pressed, it will type a unique identifier identifying the pressed hardware key. 
+- `onExit` will register a hook at the current command token, and will skip the execution of the subsequent actions on the same line (similar to `noOp`). When the macro exits, the macro will jumps to the registered hook location and resume execution. Once a `onExit` hook is fired, it will not be fire again even if other `onExit` token is encountered again. Using `final` modifier can ensure that only the `onExit` line will runs. At the moment, if a macro is broken (either due to parsing error, non-existing label, `final` or `break` command) the hook won't fires.
+  - Usage (`;` denotes newline)
+    - `onExit write hello; write bye` will results in *byehellobye*
+    - `onExit final write hello; write bye` will results in *byehello*
+    - `onExit` will overwrite any old hooks. For example, `onExit final write foo; onExit final write bar` will results in writing *bar*.
+    - Unlike label, `onExit` uses runtime information to register jump. For example,
+      ```
+      setReg 1 3
+      ifRegEq 1 1 onExit final setLedTxt 2000 ONE
+      ifRegEq 1 2 onExit final setLedTxt 2000 TWO
+      ifRegEq 1 3 onExit final setLedTxt 2000 TRE
+      ifRegEq 1 4 onExit final setLedTxt 2000 FOU
+      ifRegEq 1 5 onExit final setLedTxt 2000 FIV
+      setReg 1 5
+      ```
+      will ended up displaying "TRE" in the led.
+
 
 ### Conditions 
 

--- a/right/src/macros.h
+++ b/right/src/macros.h
@@ -74,6 +74,13 @@
         MacroResult_JumpedBackward = MacroResult_DoneFlag | MacroResult_YieldFlag,
     } macro_result_t;
 
+    typedef enum {
+        MacroHookState_Unregister,
+        MacroHookState_Registered,
+        MacroHookState_InProgress,
+        MacroHookState_Fired
+    } macro_hook_state_t;
+
     typedef struct {
         union {
             struct {
@@ -124,6 +131,7 @@
         struct {
             macro_action_t currentMacroAction;
             key_state_t *currentMacroKey;
+            macro_hook_state_t onExitHookState;
             uint32_t currentMacroStartTime;
             uint16_t currentMacroActionIndex;
             uint16_t bufferOffset;
@@ -133,6 +141,7 @@
             uint8_t currentMacroIndex;
             uint8_t postponeNextNCommands;
             uint8_t commandAddress;
+            uint8_t onExitAddress;
             uint8_t nextSlot;
             bool macroInterrupted : 1;
             bool macroSleeping : 1;


### PR DESCRIPTION
Adds an onExit hook. Usage
```
ifKeyActive 85 tapKey 1
ifKeyActive 85 onExit final setLedTxt 5000 YES
ifNotKeyActive 85 tapKey 2
ifNotKeyActive 85 onExit final setLedTxt 5000 NO

delayUntil 2000  // do work
```
Registered hook will be executed **after** the macro is exiting.
Unlike label, this hook respect runtime encounter. The example will display `YES` for L-shift+MacroKey. MacroKey without L-shift will display `NO`. In both scenario, the display happens after the whole macro had finished (after the long delay in the end)