### PR TITLE
Add conditions command for testing current keymap and layout

### DIFF
--- a/MACRO_DOCS.md
+++ b/MACRO_DOCS.md
@@ -316,6 +316,8 @@ The following grammar is supported:
     CONDITION = {ifPlaytime | ifNotPlaytime} <timeout in ms (NUMBER)>
     CONDITION = {ifShift | ifAlt | ifCtrl | ifGui | ifAnyMod | ifNotShift | ifNotAlt | ifNotCtrl | ifNotGui | ifNotAnyMod}
     CONDITION = {ifRegEq | ifNotRegEq} <register index (NUMBER)> <value (NUMBER)>
+    CONDITION = {ifKeymap | ifNotKeymap} KEYMAPID
+    CONDITION = {ifLayer | ifNotLayer} LAYERID
     CONDITION = {ifRecording | ifNotRecording}
     CONDITION = {ifRecordingId | ifNotRecordingId} MACROID
     MODIFIER = suppressMods
@@ -517,6 +519,7 @@ Conditions are checked before processing the rest of the command. If the conditi
 - `ifPlaytime/ifNotPlaytime <timeout in ms>` is true if at least `timeout` milliseconds passed since macro was started.
 - `ifShift/ifAlt/ifCtrl/ifGui/ifAnyMod/ifNotShift/ifNotAlt/ifNotCtrl/ifNotGui/ifNotAnyMod` is true if either right or left modifier was held in the previous update cycle. This does not indicate modifiers which were triggered from macroes. 
 - `{ifRegEq|ifNotRegEq} <register inex> <value>` will test if the value in the register identified by first argument equals second argument.
+- `{ifKeymap|ifNotKeymap|ifLayer|ifNotLayer} <value>` will test if the current Keymap/Layer are equals to the first argument (uses the same parsing rule as `switchKeymap` and `switchLayer`.
 - `ifRecording/ifNotRecording` and `ifRecordingId/ifNotRecordingId MACROID` test if the runtime macro recorder is in recording state. 
 - `ifShortcut/ifNotShortcut [IFSHORTCUTFLAGS]* [KEYID]*` will wait for next keypresses and compare them to the argument. See postponer mechanism section.
 - `ifGesture/ifNotGesture [IFSHORTCUTFLAGS]* [KEYID]*` just as `ifShortcut`, but breaks after 1000ms instead of when the key is released. See postponer mechanism section.

--- a/right/src/macros.c
+++ b/right/src/macros.c
@@ -1320,6 +1320,18 @@ static bool processIfRegEqCommand(bool negate, const char* arg1, const char *arg
     }
 }
 
+static bool processIfKeymapCommand(bool negate, const char* arg1, const char *argEnd)
+{
+    uint8_t queryKeymapIdx = parseKeymapId(arg1, argEnd);
+    return (queryKeymapIdx == CurrentKeymapIndex) != negate;
+}
+
+static bool processIfLayerCommand(bool negate, const char* arg1, const char *argEnd)
+{
+    uint8_t queryLayerIdx = Macros_ParseLayerId(arg1, argEnd);
+    return (queryLayerIdx == Macros_ActiveLayer) != negate;
+}
+
 static macro_result_t processBreakCommand()
 {
     s->ms.macroBroken = true;
@@ -2213,6 +2225,34 @@ static macro_result_t processCommand(const char* cmd, const char* cmdEnd)
                     return MacroResult_Finished;
                 }
                 cmd = NextTok(arg1, cmdEnd); //shift by 2
+                arg1 = NextTok(cmd, cmdEnd);
+            }
+            else if (TokenMatches(cmd, cmdEnd, "ifKeymap")) {
+                if (!processIfKeymapCommand(false, arg1, cmdEnd) && !s->as.currentConditionPassed) {
+                    return MacroResult_Finished;
+                }
+                cmd = arg1; //shift by 1
+                arg1 = NextTok(cmd, cmdEnd);
+            }
+            else if (TokenMatches(cmd, cmdEnd, "ifNotKeymap")) {
+                if (!processIfKeymapCommand(true, arg1, cmdEnd) && !s->as.currentConditionPassed) {
+                    return MacroResult_Finished;
+                }
+                cmd = arg1; //shift by 1
+                arg1 = NextTok(cmd, cmdEnd);
+            }
+            else if (TokenMatches(cmd, cmdEnd, "ifLayer")) {
+                if (!processIfLayerCommand(false, arg1, cmdEnd) && !s->as.currentConditionPassed) {
+                    return MacroResult_Finished;
+                }
+                cmd = arg1; //shift by 1
+                arg1 = NextTok(cmd, cmdEnd);
+            }
+            else if (TokenMatches(cmd, cmdEnd, "ifNotLayer")) {
+                if (!processIfLayerCommand(true, arg1, cmdEnd) && !s->as.currentConditionPassed) {
+                    return MacroResult_Finished;
+                }
+                cmd = arg1; //shift by 1
                 arg1 = NextTok(cmd, cmdEnd);
             }
             else if (TokenMatches(cmd, cmdEnd, "ifPlaytime")) {


### PR DESCRIPTION
Add conditional checks for testing the currently active layout and keymap

It allows me to use the same macro function across keymaps (with common functionality) but with slightly different intermediate behaviour depending on what keymap activates the macro.
<sub>*(well, it's not checking what triggers the macro but the currently active one, but in most practical cases this should be sufficient)*</sub>