### PR TITLE
Fix size of values in ifReg* macro commands.

### DIFF
--- a/right/src/macros.c
+++ b/right/src/macros.c
@@ -1363,7 +1363,7 @@ static bool processIfReleasedCommand(bool negate)
 static bool processIfRegEqCommand(bool negate, const char* arg1, const char *argEnd)
 {
     uint8_t address = parseNUM(arg1, argEnd);
-    uint8_t param = parseNUM(NextTok(arg1, argEnd), argEnd);
+    int32_t param = parseNUM(NextTok(arg1, argEnd), argEnd);
     if (validReg(address)) {
         bool res = regs[address] == param;
         return res != negate;
@@ -1375,7 +1375,7 @@ static bool processIfRegEqCommand(bool negate, const char* arg1, const char *arg
 static bool processIfRegInequalityCommand(bool greaterThan, const char* arg1, const char *argEnd)
 {
     uint8_t address = parseNUM(arg1, argEnd);
-    uint8_t param = parseNUM(NextTok(arg1, argEnd), argEnd);
+    int32_t param = parseNUM(NextTok(arg1, argEnd), argEnd);
     if (validReg(address)) {
         if (greaterThan) {
             return regs[address] > param;


### PR DESCRIPTION
Macro registers hold 32-bit values, but macro commands `ifRegEq`, `ifNotRegEq`, `ifRegGt` and `ifRegLt` parse `value` argument as 8-bit – this change should fix commands to use 32-bit values.