### PR TITLE
Test-Suite: handle macro arguments

### DIFF
--- a/right/src/key_action.h
+++ b/right/src/key_action.h
@@ -104,7 +104,7 @@
                 uint16_t offset;
             } ATTR_PACKED playMacro;
             struct {
-                const char* text;
+                const inline_macro_t* macro;
             } ATTR_PACKED inlineMacro;
             struct {
                 connection_action_t command;

--- a/right/src/macros/core.h
+++ b/right/src/macros/core.h
@@ -92,6 +92,9 @@
                 uint16_t textLen;
                 uint8_t cmdCount;
             } ATTR_PACKED cmd;
+            struct {
+                const inline_macro_t* inlineMacro;
+            } ATTR_PACKED inlineCmd;
         };
         macro_action_type_t type;
     } ATTR_PACKED macro_action_t;
@@ -275,8 +278,8 @@
     macro_result_t Macros_SleepTillTime(uint32_t time, const char* reason);
     uint8_t Macros_ConsumeLayerId(parser_context_t* ctx);
     uint8_t Macros_QueueMacro(uint8_t index, key_state_t *keyState, uint8_t timestamp, uint8_t queueAfterSlot);
-    uint8_t Macros_StartMacro(uint8_t index, key_state_t *keyState, uint16_t argumentOffset, uint8_t timestamp, uint8_t parentMacroSlot, bool runFirstAction, const char *inlineText);
-    uint8_t Macros_StartInlineMacro(const char *text, key_state_t *keyState, uint8_t timestamp);
+    uint8_t Macros_StartMacro(uint8_t index, key_state_t *keyState, uint16_t argumentOffset, uint8_t timestamp, uint8_t parentMacroSlot, bool runFirstAction, const inline_macro_t *inlineMacro);
+    uint8_t Macros_StartInlineMacro(const inline_macro_t *macro, key_state_t *keyState, uint8_t timestamp);
     uint8_t Macros_TryConsumeKeyId(parser_context_t* ctx);
     void Macros_ContinueMacro(void);
     void Macros_Initialize();

--- a/right/src/str_utils.h
+++ b/right/src/str_utils.h
@@ -52,6 +52,12 @@
         const char* end;
     } ATTR_PACKED string_segment_t;
 
+    typedef struct {
+        const char* text;
+        const string_segment_t* args;
+        uint8_t argCount;
+    } inline_macro_t;
+
 
 // Functions:
 

--- a/right/src/test_suite/test_actions.h
+++ b/right/src/test_suite/test_actions.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "str_utils.h"
 
 // Helper macros for defining tests
 
@@ -34,7 +35,11 @@
 
 // SetMacro: assign an inline macro to a key
 #define TEST_SET_MACRO(key_id, macro_text) \
-    { .type = TestAction_SetMacro, .keyId = (key_id), .macroText = (macro_text) }
+    { .type = TestAction_SetMacro, .keyId = (key_id), .inlineMacro = &(const inline_macro_t){ .text = (macro_text), .args = NULL, .argCount = 0 } }
+
+// SetMacroWithArgs: assign an inline macro with arguments to a key
+#define TEST_SET_MACRO_WITH_ARGS(key_id, macro_text, args_ptr, arg_count) \
+    { .type = TestAction_SetMacro, .keyId = (key_id), .inlineMacro = &(const inline_macro_t){ .text = (macro_text), .args = (args_ptr), .argCount = (arg_count) } }
 
 // SetLayerHold: assign a layer hold action to a key
 #define TEST_SET_LAYER_HOLD(key_id, layer_id) \
@@ -84,7 +89,7 @@ typedef struct {
         uint16_t delayMs;
         const char *expectShortcuts;  // Space-separated shortcut strings
         const char *shortcutStr;      // For SetAction, SetLayerAction
-        const char *macroText;        // For SetMacro
+        const inline_macro_t *inlineMacro;  // For SetMacro
         const char *configText;       // For SetConfig
     };
 } test_action_t;

--- a/right/src/test_suite/test_input_machine.c
+++ b/right/src/test_suite/test_input_machine.c
@@ -225,12 +225,12 @@ void InputMachine_Tick(void) {
                 key_action_t keyAction = {
                     .type = KeyActionType_InlineMacro,
                     .inlineMacro = {
-                        .text = action->macroText
+                        .macro = action->inlineMacro
                     }
                 };
 
                 CurrentKeymap[LayerId_Base][slotId][keyId] = keyAction;
-                LOG_VERBOSE("[TEST] > SetMacro [%s] = '%s'\n", action->keyId, action->macroText);
+                LOG_VERBOSE("[TEST] > SetMacro [%s] = '%s'\n", action->keyId, action->inlineMacro->text);
                 InputMachine_ActionIndex++;
                 break;
             }

--- a/right/src/usb_commands/usb_command_exec_macro_command.c
+++ b/right/src/usb_commands/usb_command_exec_macro_command.c
@@ -1,6 +1,7 @@
 #ifndef __ZEPHYR__
 #include "fsl_common.h"
 #endif
+#include "str_utils.h"
 #include "macros/core.h"
 #include "macros/status_buffer.h"
 #include "usb_commands/usb_command_exec_macro_command.h"
@@ -14,6 +15,7 @@
 char UsbMacroCommand[USB_GENERIC_HID_OUT_BUFFER_LENGTH+1];
 uint8_t UsbMacroCommandLength = 0;
 key_state_t dummyState;
+static inline_macro_t usbInlineMacro = { .text = UsbMacroCommand, .args = NULL, .argCount = 0 };
 
 static void requestExecution(const uint8_t *GenericHidOutBuffer)
 {
@@ -42,7 +44,7 @@ static bool canExecute()
 
 void UsbMacroCommand_ExecuteSynchronously()
 {
-    Macros_StartMacro(MacroIndex_InlineMacro, &dummyState, 0, 255, MacroIndex_None, false, UsbMacroCommand);
+    Macros_StartMacro(MacroIndex_InlineMacro, &dummyState, 0, 255, MacroIndex_None, false, &usbInlineMacro);
     EventVector_Unset(EventVector_UsbMacroCommandWaitingForExecution);
 }
 

--- a/right/src/usb_report_updater.c
+++ b/right/src/usb_report_updater.c
@@ -475,7 +475,7 @@ void ApplyKeyAction(key_state_t *keyState, key_action_cached_t *cachedAction, ke
         case KeyActionType_InlineMacro:
             if (KeyState_ActivatedNow(keyState)) {
                 resetStickyMods(cachedAction);
-                Macros_StartInlineMacro(action->inlineMacro.text, keyState, keyState->activationTimestamp);
+                Macros_StartInlineMacro(action->inlineMacro.macro, keyState, keyState->activationTimestamp);
             }
             break;
         case KeyActionType_Connections:


### PR DESCRIPTION
## Summary
- Add `inline_macro_t` struct to support inline macros with arguments
- Update `key_action_t.inlineMacro` to use pointer to `inline_macro_t`
- Add `TEST_SET_MACRO_WITH_ARGS` test macro for parameterized inline macros
- Implement `getMacroArgument` helper that checks inline args first, then config buffer

## Test plan
- [ ] Verify build succeeds
- [ ] Test inline macros with arguments in test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)