### PR TITLE
TestSuite: add environment passes for postponing tests

### DIFF
--- a/right/src/test_suite/test_actions.h
+++ b/right/src/test_suite/test_actions.h
@@ -4,6 +4,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+// Environment flags for tests
+#define TEST_ENV_POSTPONING 0x01
+
 // Helper macros for defining tests
 
 #define TEST_PRESS______(key_id) \
@@ -94,6 +97,7 @@ typedef struct {
 typedef struct {
     const char *name;
     const test_action_t *actions;
+    uint8_t envFlags;  // Bitmask of TEST_ENV_* flags
 } test_t;
 
 #endif

--- a/right/src/test_suite/tests/test_autorepeat.c
+++ b/right/src/test_suite/tests/test_autorepeat.c
@@ -62,8 +62,8 @@ static const test_action_t test_autorepeat_with_modifier[] = {
 };
 
 static const test_t autorepeat_tests[] = {
-    { .name = "autorepeat_basic", .actions = test_autorepeat_basic },
-    { .name = "autorepeat_with_modifier", .actions = test_autorepeat_with_modifier },
+    { .name = "autorepeat_basic", .actions = test_autorepeat_basic, .envFlags = TEST_ENV_POSTPONING },
+    { .name = "autorepeat_with_modifier", .actions = test_autorepeat_with_modifier, .envFlags = TEST_ENV_POSTPONING },
 };
 
 const test_module_t TestModule_Autorepeat = {

--- a/right/src/test_suite/tests/test_autoshift.c
+++ b/right/src/test_suite/tests/test_autoshift.c
@@ -102,11 +102,11 @@ static const test_action_t test_autoshift_disabled[] = {
 };
 
 static const test_t autoshift_tests[] = {
-    { .name = "basic",         .actions = test_autoshift_basic },
-    { .name = "hold",          .actions = test_autoshift_hold },
-    { .name = "with_modifier", .actions = test_autoshift_with_modifier },
-    { .name = "number",        .actions = test_autoshift_number },
-    { .name = "disabled",      .actions = test_autoshift_disabled },
+    { .name = "basic",         .actions = test_autoshift_basic, .envFlags = TEST_ENV_POSTPONING },
+    { .name = "hold",          .actions = test_autoshift_hold, .envFlags = TEST_ENV_POSTPONING },
+    { .name = "with_modifier", .actions = test_autoshift_with_modifier, .envFlags = TEST_ENV_POSTPONING },
+    { .name = "number",        .actions = test_autoshift_number, .envFlags = TEST_ENV_POSTPONING },
+    { .name = "disabled",      .actions = test_autoshift_disabled, .envFlags = TEST_ENV_POSTPONING },
 };
 
 const test_module_t TestModule_AutoShift = {

--- a/right/src/test_suite/tests/test_basic.c
+++ b/right/src/test_suite/tests/test_basic.c
@@ -32,8 +32,8 @@ static const test_action_t test_two_keys[] = {
 };
 
 static const test_t basic_tests[] = {
-    { .name = "basic_keypress", .actions = test_basic_keypress },
-    { .name = "two_keys", .actions = test_two_keys },
+    { .name = "basic_keypress", .actions = test_basic_keypress, .envFlags = TEST_ENV_POSTPONING },
+    { .name = "two_keys", .actions = test_two_keys, .envFlags = TEST_ENV_POSTPONING },
 };
 
 const test_module_t TestModule_Basic = {

--- a/right/src/test_suite/tests/test_chording.c
+++ b/right/src/test_suite/tests/test_chording.c
@@ -82,9 +82,9 @@ static const test_action_t test_chording_disabled[] = {
 };
 
 static const test_t chording_tests[] = {
-    { .name = "basic",          .actions = test_chording_basic },
-    { .name = "layer_priority", .actions = test_chording_layer_priority },
-    { .name = "disabled",       .actions = test_chording_disabled },
+    { .name = "basic",          .actions = test_chording_basic, .envFlags = TEST_ENV_POSTPONING },
+    { .name = "layer_priority", .actions = test_chording_layer_priority, .envFlags = TEST_ENV_POSTPONING },
+    { .name = "disabled",       .actions = test_chording_disabled, .envFlags = TEST_ENV_POSTPONING },
 };
 
 const test_module_t TestModule_Chording = {

--- a/right/src/test_suite/tests/test_ifshortcut_gesture.c
+++ b/right/src/test_suite/tests/test_ifshortcut_gesture.c
@@ -370,23 +370,23 @@ static const test_action_t test_ifgesture_cancelin[] = {
 
 static const test_t ifshortcut_gesture_tests[] = {
     // ifShortcut tests
-    { .name = "ifshortcut_basic",      .actions = test_ifshortcut_basic },
-    { .name = "ifshortcut_no_match",   .actions = test_ifshortcut_no_match },
-    { .name = "ifnotshortcut",         .actions = test_ifnotshortcut },
-    { .name = "ifshortcut_noconsume",  .actions = test_ifshortcut_noconsume },
-    { .name = "ifshortcut_anyorder",   .actions = test_ifshortcut_anyorder },
-    { .name = "ifshortcut_orgate",     .actions = test_ifshortcut_orgate },
-    { .name = "ifshortcut_timeout",    .actions = test_ifshortcut_timeout },
-    { .name = "ifshortcut_transitive", .actions = test_ifshortcut_transitive },
+    { .name = "ifshortcut_basic",      .actions = test_ifshortcut_basic, .envFlags = TEST_ENV_POSTPONING },
+    { .name = "ifshortcut_no_match",   .actions = test_ifshortcut_no_match, .envFlags = TEST_ENV_POSTPONING },
+    { .name = "ifnotshortcut",         .actions = test_ifnotshortcut, .envFlags = TEST_ENV_POSTPONING },
+    { .name = "ifshortcut_noconsume",  .actions = test_ifshortcut_noconsume, .envFlags = TEST_ENV_POSTPONING },
+    { .name = "ifshortcut_anyorder",   .actions = test_ifshortcut_anyorder, .envFlags = TEST_ENV_POSTPONING },
+    { .name = "ifshortcut_orgate",     .actions = test_ifshortcut_orgate, .envFlags = TEST_ENV_POSTPONING },
+    { .name = "ifshortcut_timeout",    .actions = test_ifshortcut_timeout, .envFlags = TEST_ENV_POSTPONING },
+    { .name = "ifshortcut_transitive", .actions = test_ifshortcut_transitive, .envFlags = TEST_ENV_POSTPONING },
     // ifGesture tests
-    { .name = "ifgesture_basic",       .actions = test_ifgesture_basic },
-    { .name = "ifgesture_doubletap",   .actions = test_ifgesture_doubletap },
-    { .name = "ifnotgesture",          .actions = test_ifnotgesture },
-    { .name = "ifgesture_noconsume",   .actions = test_ifgesture_noconsume },
-    { .name = "ifgesture_anyorder",    .actions = test_ifgesture_anyorder },
-    { .name = "ifgesture_orgate",      .actions = test_ifgesture_orgate },
-    { .name = "ifgesture_timeout",     .actions = test_ifgesture_timeout },
-    { .name = "ifgesture_cancelin",    .actions = test_ifgesture_cancelin },
+    { .name = "ifgesture_basic",       .actions = test_ifgesture_basic, .envFlags = TEST_ENV_POSTPONING },
+    { .name = "ifgesture_doubletap",   .actions = test_ifgesture_doubletap, .envFlags = TEST_ENV_POSTPONING },
+    { .name = "ifnotgesture",          .actions = test_ifnotgesture, .envFlags = TEST_ENV_POSTPONING },
+    { .name = "ifgesture_noconsume",   .actions = test_ifgesture_noconsume, .envFlags = TEST_ENV_POSTPONING },
+    { .name = "ifgesture_anyorder",    .actions = test_ifgesture_anyorder, .envFlags = TEST_ENV_POSTPONING },
+    { .name = "ifgesture_orgate",      .actions = test_ifgesture_orgate, .envFlags = TEST_ENV_POSTPONING },
+    { .name = "ifgesture_timeout",     .actions = test_ifgesture_timeout, .envFlags = TEST_ENV_POSTPONING },
+    { .name = "ifgesture_cancelin",    .actions = test_ifgesture_cancelin, .envFlags = 0 },  // Uses TEST_CHECK_NOW
 };
 
 const test_module_t TestModule_IfShortcutGesture = {

--- a/right/src/test_suite/tests/test_layers.c
+++ b/right/src/test_suite/tests/test_layers.c
@@ -43,8 +43,8 @@ static const test_action_t test_layer_hold_with_modifier[] = {
 };
 
 static const test_t layer_tests[] = {
-    { .name = "layer_hold", .actions = test_layer_hold },
-    { .name = "layer_hold_with_modifier", .actions = test_layer_hold_with_modifier },
+    { .name = "layer_hold", .actions = test_layer_hold, .envFlags = TEST_ENV_POSTPONING },
+    { .name = "layer_hold_with_modifier", .actions = test_layer_hold_with_modifier, .envFlags = TEST_ENV_POSTPONING },
 };
 
 const test_module_t TestModule_Layers = {

--- a/right/src/test_suite/tests/test_macros.c
+++ b/right/src/test_suite/tests/test_macros.c
@@ -36,8 +36,8 @@ static const test_action_t test_macro_with_modifier[] = {
 };
 
 static const test_t macro_tests[] = {
-    { .name = "macro_two_tapkeys", .actions = test_macro_two_tapkeys },
-    { .name = "macro_with_modifier", .actions = test_macro_with_modifier },
+    { .name = "macro_two_tapkeys", .actions = test_macro_two_tapkeys, .envFlags = TEST_ENV_POSTPONING },
+    { .name = "macro_with_modifier", .actions = test_macro_with_modifier, .envFlags = TEST_ENV_POSTPONING },
 };
 
 const test_module_t TestModule_Macros = {

--- a/right/src/test_suite/tests/test_modifiers.c
+++ b/right/src/test_suite/tests/test_modifiers.c
@@ -16,7 +16,7 @@ static const test_action_t test_modifier_keystroke[] = {
 };
 
 static const test_t modifier_tests[] = {
-    { .name = "modifier_keystroke", .actions = test_modifier_keystroke },
+    { .name = "modifier_keystroke", .actions = test_modifier_keystroke, .envFlags = TEST_ENV_POSTPONING },
 };
 
 const test_module_t TestModule_Modifiers = {

--- a/right/src/test_suite/tests/test_oneshot.c
+++ b/right/src/test_suite/tests/test_oneshot.c
@@ -46,7 +46,7 @@ static const test_action_t test_oneshot_modifiers[] = {
 };
 
 static const test_t oneshot_tests[] = {
-    { .name = "oneshot_modifiers", .actions = test_oneshot_modifiers },
+    { .name = "oneshot_modifiers", .actions = test_oneshot_modifiers, .envFlags = TEST_ENV_POSTPONING },
 };
 
 const test_module_t TestModule_Oneshot = {

--- a/right/src/test_suite/tests/test_secondary_roles.c
+++ b/right/src/test_suite/tests/test_secondary_roles.c
@@ -74,8 +74,8 @@ static const test_action_t test_secondary_role_negative_safety[] = {
 };
 
 static const test_t secondary_role_tests[] = {
-    { .name = "positive_safety_margin", .actions = test_secondary_role_positive_safety },
-    { .name = "negative_safety_margin", .actions = test_secondary_role_negative_safety },
+    { .name = "positive_safety_margin", .actions = test_secondary_role_positive_safety, .envFlags = TEST_ENV_POSTPONING },
+    { .name = "negative_safety_margin", .actions = test_secondary_role_negative_safety, .envFlags = TEST_ENV_POSTPONING },
 };
 
 const test_module_t TestModule_SecondaryRoles = {


### PR DESCRIPTION
## Summary
- Add `TEST_ENV_POSTPONING` flag and `envFlags` field to `test_t` struct
- Implement environment pass system:
  - Pass 0: All tests run normally
  - Pass 1: Tests with `TEST_ENV_POSTPONING` flag run with prologue/epilogue
- Prologue: presses a key with `postponeKeys delayUntilRelease` macro
- Epilogue: verifies postponing works via `CHECK_NOW("")`, then releases
- All existing tests get `TEST_ENV_POSTPONING` except `ifgesture_cancelin` (uses CHECK_NOW)

This supports testing the "time machine" functionality where the macro engine delays evaluation.

## Test plan
- [ ] Verify build succeeds
- [ ] Run test suite and verify environment passes work correctly
- [ ] Verify tests with CHECK_NOW are excluded from postponing environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)