### PR TITLE
Rolling buffer: shift by 256 chars to next newline

### DIFF
--- a/right/src/macros/status_buffer.c
+++ b/right/src/macros/status_buffer.c
@@ -125,9 +125,13 @@ static void setStatusChar(char n)
     }
 
     if (n && Buf.len == STATUS_BUFFER_MAX_LENGTH && DEBUG_ROLL_STATUS_BUFFER) {
-        memcpy(Buf.data, &Buf.data[STATUS_BUFFER_MAX_LENGTH/2], STATUS_BUFFER_MAX_LENGTH/2);
-        int16_t shiftBy = STATUS_BUFFER_MAX_LENGTH - STATUS_BUFFER_MAX_LENGTH/2;
-        Buf.len = STATUS_BUFFER_MAX_LENGTH/2;
+        uint16_t shiftBy = 256;
+        while (shiftBy < Buf.len && Buf.data[shiftBy - 1] != '\n') {
+            shiftBy++;
+        }
+        uint16_t remaining = Buf.len - shiftBy;
+        memmove(Buf.data, &Buf.data[shiftBy], remaining);
+        Buf.len = remaining;
         consumeStatusCharReadingPos = consumeStatusCharReadingPos > shiftBy ? consumeStatusCharReadingPos - shiftBy : 0;
     }
 


### PR DESCRIPTION
## Summary
- When rolling is enabled and the status buffer is full, shift by 256 chars plus continue until the next newline, instead of shifting by half the buffer
- Uses `memmove` instead of `memcpy` for correctness
- Aligns the shift to line boundaries for cleaner output

## Test plan
- [ ] Enable `DEBUG_ROLL_STATUS_BUFFER` and fill the status buffer past capacity
- [ ] Verify the buffer rolls at a newline boundary after at least 256 chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)