### PR TITLE
K-boot flashing analysis documentation

### DIFF
--- a/doc-dev/other/flashing/README.md
+++ b/doc-dev/other/flashing/README.md
@@ -1,0 +1,103 @@
+# Firmware Flashing Implementation
+
+This directory contains documentation for implementing autonomous module firmware flashing on the UHK right half.
+
+## Goal
+
+Move K-boot protocol implementation from the Agent (desktop tool) to the right half firmware, enabling autonomous module firmware updates without Agent involvement in the flashing process.
+
+## Documentation Files
+
+| File | Description |
+|------|-------------|
+| [configuration-buffer.md](configuration-buffer.md) | Config buffer APIs and memory layout |
+| [usb-communication.md](usb-communication.md) | USB command infrastructure |
+| [module-communication.md](module-communication.md) | I2C/UART slave scheduler and module discovery |
+| [kboot-protocol.md](kboot-protocol.md) | K-boot protocol details for porting |
+
+## Current Architecture
+
+```
+┌─────────────┐      USB        ┌─────────────┐      I2C       ┌─────────────┐
+│   Agent     │ ────────────────▶│  Right Half │ ───────────────▶│   Module    │
+│  (Desktop)  │                 │  (Buspal)   │                │ (Bootloader)│
+└─────────────┘                 └─────────────┘                └─────────────┘
+       │                              │                              │
+       │  K-boot protocol            │  Forward packets             │
+       │  implementation             │  transparently               │
+       │                              │                              │
+```
+
+**Problem**: K-boot protocol logic is in the Agent. Right half only forwards packets.
+
+## Target Architecture
+
+```
+┌─────────────┐      USB        ┌─────────────┐      I2C       ┌─────────────┐
+│   Agent     │ ────────────────▶│  Right Half │ ───────────────▶│   Module    │
+│  (Desktop)  │                 │  (K-boot)   │                │ (Bootloader)│
+└─────────────┘                 └─────────────┘                └─────────────┘
+       │                              │                              │
+       │  Upload firmware            │  K-boot protocol             │
+       │  binary only                │  implementation              │
+       │                              │                              │
+```
+
+**Goal**: Agent uploads firmware binary. Right half handles K-boot protocol.
+
+## Two-Phase Implementation
+
+### Phase 1: USB Transfer to Right Half
+
+1. Analyze existing configuration buffer APIs (see [configuration-buffer.md](configuration-buffer.md))
+2. Design firmware upload protocol
+3. Implement chunked USB transfer (similar to config write)
+4. Store firmware in staging buffer or stream directly
+
+### Phase 2: Right Half to Module
+
+1. Port K-boot protocol from Agent (see [kboot-protocol.md](kboot-protocol.md))
+2. Implement I2C transport layer
+3. Implement flashing state machine:
+   - Reboot module to bootloader
+   - Erase flash
+   - Write firmware chunks
+   - Verify and reset
+
+## Proposed USB Commands
+
+| Command | ID | Description |
+|---------|-----|-------------|
+| StartModuleFirmwareUpload | 0x20 | Begin firmware upload (module ID, size) |
+| WriteModuleFirmwareChunk | 0x21 | Write firmware data chunk |
+| FlashModule | 0x22 | Start flashing (uses uploaded firmware) |
+| GetFlashingStatus | 0x23 | Query flashing progress |
+| AbortFlashing | 0x24 | Cancel flashing operation |
+
+## Key Challenges
+
+1. **Memory**: Module firmware (~40-60 KB) exceeds config buffer (~32 KB)
+   - Solution: Stream directly to module, or use UHK80 external flash
+
+2. **Timing**: I2C transfers while maintaining keyboard responsiveness
+   - Solution: Use slave scheduler, low priority for flashing
+
+3. **Error Recovery**: Handle I2C failures, power loss during flash
+   - Solution: Verify writes, implement retry logic
+
+4. **State Management**: Track flashing progress across multiple USB commands
+   - Solution: Implement state machine with persistent state
+
+## Technical Constraints
+
+- Firmware must fit in available RAM or be streamed
+- K-boot protocol requires both I2C and UART support
+- Must handle communication failures gracefully
+- Module must remain functional if flashing fails
+
+## Success Criteria
+
+- [ ] Firmware can be uploaded to right half via USB
+- [ ] Right half can autonomously flash connected module
+- [ ] No dependency on Agent for K-boot protocol execution
+- [ ] Agent only uploads firmware binary, doesn't manage flashing

--- a/doc-dev/other/flashing/configuration-buffer.md
+++ b/doc-dev/other/flashing/configuration-buffer.md
@@ -1,0 +1,141 @@
+# Configuration Buffer APIs
+
+This document describes the user configuration buffer system that could potentially be used for firmware image storage during module flashing.
+
+## Buffer Architecture
+
+The firmware uses a **three-buffer system** for configuration management:
+
+```c
+typedef enum {
+    ConfigBufferId_HardwareConfig,
+    ConfigBufferId_StagingUserConfig,
+    ConfigBufferId_ValidatedUserConfig,
+} config_buffer_id_t;
+```
+
+### Memory Sizes
+
+| Platform | Hardware Config | User Config |
+|----------|----------------|-------------|
+| UHK60    | 64 bytes       | 32,704 bytes |
+| UHK80    | 64 bytes       | 32,768 bytes |
+
+**Note**: Module firmware images are typically 40-60 KB for UHK60 modules, which exceeds the current user config buffer capacity. Alternative storage strategies may be needed.
+
+## Core Data Structures
+
+### Buffer Structure
+
+From `right/src/config_parser/basic_types.h`:
+
+```c
+typedef struct {
+    bool isValid;       // Flag indicating if buffer contains valid configuration
+    uint8_t *buffer;    // Pointer to raw byte buffer
+    uint16_t offset;    // Current read/write position for parsing
+} config_buffer_t;
+```
+
+### Buffer Instances
+
+From `right/src/config_parser/config_globals.c`:
+
+```c
+config_buffer_t HardwareConfigBuffer;
+config_buffer_t StagingUserConfigBuffer;
+config_buffer_t ValidatedUserConfigBuffer;
+```
+
+## Key Functions
+
+### Buffer Access
+
+```c
+// Get buffer descriptor from ID
+config_buffer_t* ConfigBufferIdToConfigBuffer(config_buffer_id_t configBufferId);
+
+// Get buffer size
+uint16_t ConfigBufferIdToBufferSize(config_buffer_id_t configBufferId);
+
+// Validate buffer ID
+bool IsConfigBufferIdValid(config_buffer_id_t configBufferId);
+```
+
+### Parsing Primitives
+
+From `right/src/config_parser/basic_types.h`:
+
+```c
+uint8_t ReadUInt8(config_buffer_t *buffer);
+uint16_t ReadUInt16(config_buffer_t *buffer);
+uint32_t ReadUInt32(config_buffer_t *buffer);
+```
+
+## USB Read/Write APIs
+
+### Read Config Command
+
+**File**: `right/src/usb_commands/usb_command_read_config.c`
+
+**Protocol**:
+- Byte 0: Command (0x04)
+- Byte 1: Config buffer ID
+- Byte 2: Length to read (max 62 bytes)
+- Bytes 3-4: Offset (little-endian uint16)
+- Response: [Status(1)] [Data(length)]
+
+### Write Config Command
+
+**File**: `right/src/usb_commands/usb_command_write_config.c`
+
+**Protocol**:
+- Byte 0: Command (0x05 or 0x06)
+- Byte 1: Length to write
+- Bytes 2-3: Offset (little-endian uint16)
+- Bytes 4+: Data to write (max 59 bytes per packet)
+
+## Storage Operations
+
+### UHK60 - EEPROM
+
+**File**: `right/src/eeprom.c`
+
+```c
+status_t EEPROM_LaunchTransfer(storage_operation_t operation,
+                               config_buffer_id_t configBufferId,
+                               void (*successCallback));
+```
+
+- I2C-based EEPROM at 100 kHz (I2C1 at 1 MHz)
+- 64-byte page writes
+- Sequential page writes with callbacks
+
+### UHK80 - Flash
+
+**File**: `device/src/flash.c`
+
+```c
+uint8_t Flash_LaunchTransfer(storage_operation_t operation,
+                             config_buffer_id_t configBufferId,
+                             void (*successCallback));
+```
+
+- Flash area API with 4K alignment
+- Erase before write required
+
+## Implications for Firmware Storage
+
+Current configuration buffer capacity (~32 KB) is insufficient for typical module firmware images (~40-60 KB). Options include:
+
+1. **Streaming approach**: Transfer firmware in chunks directly to module without storing in RAM
+2. **External storage**: Use separate flash region on UHK80
+3. **Multiple transfers**: Split firmware and transfer in multiple sessions
+
+## Key Source Files
+
+- `right/src/config_manager.h` - Runtime config struct
+- `right/src/config_parser/config_globals.h` - Buffer types & IDs
+- `right/src/config_parser/basic_types.h` - Parsing primitives
+- `right/src/eeprom.c` - UHK60 storage
+- `device/src/flash.c` - UHK80 storage

--- a/doc-dev/other/flashing/firmware-upload-proposal.md
+++ b/doc-dev/other/flashing/firmware-upload-proposal.md
@@ -1,0 +1,156 @@
+# Firmware Upload Proposal
+
+## Current UserConfig Flashing Flow
+
+```
+Agent                                    Firmware
+  |                                         |
+  |  1. WriteStagingUserConfig (0x06)       |
+  |     [cmd, len, offsetLo, offsetHi, data...]
+  |  ---------------------------------------->
+  |     (repeat for each 59-byte chunk)     |
+  |                                         |
+  |  2. ApplyConfig (0x07)                  |
+  |  ---------------------------------------->
+  |     Validates & swaps staging→validated |
+  |                                         |
+  |  3. LaunchEepromTransfer (0x08)         |
+  |     [cmd, operation=write, bufferId]    |
+  |  ---------------------------------------->
+  |     Writes validated buffer to EEPROM   |
+  |                                         |
+  |  4. GetDeviceState (0x09) - poll        |
+  |  ---------------------------------------->
+  |  <-- isEepromBusy until done            |
+```
+
+### USB Packet Format (63 bytes max)
+
+```
+WriteConfig packet:
+  [0] = UsbCommand (0x05 or 0x06)
+  [1] = length (1-59)
+  [2] = offset low byte
+  [3] = offset high byte
+  [4-62] = data (up to 59 bytes)
+```
+
+### Agent Code Reference
+
+```typescript
+// lib/agent/packages/uhk-usb/src/util.ts
+function getTransferBuffers(usbCommand, configBuffer) {
+    const MAX_SENDING_PAYLOAD_SIZE = 59;  // 63 - 4 byte header
+    for (let offset = 0; offset < configBuffer.length; offset += 59) {
+        const header = [usbCommand, length, offset & 0xFF, offset >> 8];
+        fragments.push(concat(header, configBuffer.slice(offset, offset + 59)));
+    }
+}
+
+// lib/agent/packages/uhk-usb/src/uhk-operations.ts
+async saveUserConfiguration(buffer) {
+    await sendConfigToKeyboard(buffer, true);      // WriteStagingUserConfig chunks
+    await applyConfiguration();                     // ApplyConfig
+    await writeConfigToEeprom(validatedUserConfig); // LaunchEepromTransfer
+    await waitUntilKeyboardBusy();                  // Poll GetDeviceState
+}
+```
+
+## Proposed Firmware Upload API
+
+Reuse the same chunked transfer pattern, but target module firmware instead of config buffers.
+
+### New USB Commands
+
+| ID | Command | Parameters |
+|----|---------|------------|
+| 0x20 | WriteModuleFirmware | [len, offsetLo, offsetHi, data...] |
+| 0x21 | FlashModule | [slotId] |
+| 0x22 | GetModuleFlashState | - |
+
+### Proposed Flow
+
+```
+Agent                                    Firmware
+  |                                         |
+  |  1. WriteModuleFirmware (0x20)          |
+  |     [cmd, len, offsetLo, offsetHi, data...]
+  |  ---------------------------------------->
+  |     (repeat for each 59-byte chunk)     |
+  |     Streams directly to module via I2C  |
+  |                                         |
+  |  2. FlashModule (0x21)                  |
+  |     [cmd, slotId]                       |
+  |  ---------------------------------------->
+  |     Finalizes flash, resets module      |
+  |                                         |
+  |  3. GetModuleFlashState (0x22) - poll   |
+  |  ---------------------------------------->
+  |  <-- status: idle/erasing/writing/done  |
+```
+
+### Implementation Options
+
+**Option A: Streaming (preferred for UHK60)**
+- Each WriteModuleFirmware chunk is immediately forwarded to module via I2C
+- No RAM buffer needed on right half
+- Module bootloader receives K-boot WriteMemory commands directly
+
+**Option B: Buffered (if streaming not possible)**
+- Store firmware in staging buffer (limited to ~32KB)
+- FlashModule reads from buffer and sends to module
+- Requires multiple passes for larger firmware
+
+### Agent Code Changes
+
+```typescript
+// Minimal changes - reuse existing pattern
+async flashModuleFirmware(slotId: number, firmwareBuffer: Buffer) {
+    // Same chunked transfer, different command
+    const fragments = getTransferBuffers(0x20, firmwareBuffer);
+    for (const fragment of fragments) {
+        await this.device.write(fragment);
+    }
+
+    // Trigger flash
+    await this.device.write(Buffer.from([0x21, slotId]));
+
+    // Wait for completion
+    while (true) {
+        const state = await this.device.write(Buffer.from([0x22]));
+        if (state[1] === FlashState.Done) break;
+        if (state[1] === FlashState.Error) throw new Error(state[2]);
+        await snooze(100);
+    }
+}
+```
+
+### Firmware Side Implementation
+
+```c
+// New command handlers in usb_commands/
+
+void UsbCommand_WriteModuleFirmware(const uint8_t *in, uint8_t *out) {
+    uint8_t length = GetUsbRxBufferUint8(1);
+    uint16_t offset = GetUsbRxBufferUint16(2);
+    const uint8_t *data = in + 4;
+
+    // Stream to module bootloader via I2C (K-boot WriteMemory)
+    KbootDriver_WriteMemory(offset, data, length);
+}
+
+void UsbCommand_FlashModule(const uint8_t *in, uint8_t *out) {
+    uint8_t slotId = GetUsbRxBufferUint8(1);
+
+    // Send K-boot Reset command to module
+    KbootDriver_Reset(slotId);
+}
+```
+
+## Summary
+
+The existing config transfer infrastructure (chunked USB, 59-byte payloads, 16-bit offset) can be reused directly for firmware upload. The main work is:
+
+1. Add 3 new USB command handlers
+2. Implement K-boot I2C driver (WriteMemory, Reset commands)
+3. Handle the streaming/forwarding in firmware instead of Agent

--- a/doc-dev/other/flashing/kboot-protocol.md
+++ b/doc-dev/other/flashing/kboot-protocol.md
@@ -1,0 +1,194 @@
+# K-Boot Protocol
+
+This document describes the K-boot bootloader protocol used for flashing module firmware. The protocol is currently implemented in the Agent (TypeScript) and needs to be ported to the right half firmware.
+
+## Protocol Overview
+
+K-boot is NXP's bootloader protocol for Kinetis MCUs. The UHK uses it for:
+- Direct USB flashing of the right half (KL04 bootloader)
+- I2C-forwarded flashing of modules via Buspal mode
+
+## Command IDs
+
+From `lib/agent/packages/kboot/src/enums/commands.ts`:
+
+| ID | Command | Description |
+|----|---------|-------------|
+| 0x01 | FlashEraseAll | Erase entire flash |
+| 0x02 | FlashEraseRegion | Erase region (start + count) |
+| 0x03 | ReadMemory | Read from address |
+| 0x04 | WriteMemory | Write to address (has data phase) |
+| 0x05 | FillMemory | Fill memory region |
+| 0x06 | FlashSecurityDisable | Unlock flash (8-byte key) |
+| 0x07 | GetProperty | Query bootloader property |
+| 0x0B | Reset | Reset to firmware |
+| 0x0C | SetProperty | Set bootloader property |
+| 0x0D | FlashEraseAllUnsecure | Erase all (unsecured) |
+| 0xC1 | ConfigureI2c | Configure I2C for buspal |
+
+## Packet Structure
+
+### Command Packet (32 bytes)
+
+```
+Header (4 bytes):
+  [0] = 1                      // Channel (always 1 for commands)
+  [1] = 0                      // Reserved
+  [2-3] = Payload length       // Little-endian 16-bit
+
+Payload (variable):
+  [0] = Command ID
+  [1] = HasDataPhase flag      // 1 if data follows, 0 otherwise
+  [2] = 0                      // Reserved
+  [3] = Param count            // Number of 4-byte parameters
+  [4+] = Parameters            // 32-bit little-endian each
+
+Padding: Fill to 32 bytes with zeros
+```
+
+### Response Packet
+
+```
+Header (4 bytes):
+  [0] = 3                      // Channel (always 3 for response)
+  [1] = Reserved
+  [2-3] = Response data length
+
+Response Data:
+  [4] = ResponseTag            // 0xA0=generic, 0xA3=readMem, 0xA7=property
+  [5-7] = Reserved
+  [8-10] = ResponseCode        // 24-bit little-endian status
+  [11+] = Response-specific data
+```
+
+### Data Packet (WriteMemory data phase)
+
+```
+[0] = 2                        // Channel 2 (data)
+[1] = 0
+[2] = Data chunk length        // 1-28 bytes typically
+[3] = 0
+[4+] = Actual firmware data
+```
+
+## Response Tags
+
+| Tag | Description |
+|-----|-------------|
+| 0xA0 | Generic response |
+| 0xA3 | ReadMemory response |
+| 0xA7 | Property response |
+| 0xAF | FlashReadOnce response |
+
+## Response Codes
+
+| Code | Description |
+|------|-------------|
+| 0 | Success |
+| 1 | Fail |
+| 2 | ReadOnly |
+| 3 | OutOfRange |
+| 4 | InvalidArgument |
+| 100-106 | Flash driver errors |
+| 200-202 | I2C driver errors |
+| 10000-10005 | Bootloader errors |
+
+## Properties
+
+| ID | Property |
+|----|----------|
+| 0x01 | BootloaderVersion |
+| 0x03 | FlashStartAddress |
+| 0x04 | FlashSize |
+| 0x05 | FlashSectorSize |
+| 0x0B | MaxPacketSize |
+| 0x0E | RAMStartAddress |
+| 0x0F | RAMSize |
+| 0x11 | FlashSecurityState |
+
+## Flashing State Machine
+
+### Right Half (Direct USB)
+
+1. Reenumerate device into bootloader mode
+2. Create KBoot USB peripheral instance
+3. `flashSecurityDisable([0x01-0x08])` - Unlock flash
+4. `flashEraseRegion(0xC000, 475136)` - Erase application region
+5. Read firmware from .hex file
+6. `writeMemory(startAddress, data)` - Write in chunks
+7. `reset()` - Reboot to firmware
+
+### Module (I2C via Buspal)
+
+1. Reenumerate to NormalKeyboard mode
+2. Send ping to module via I2C (100 retries)
+3. Send jump-to-bootloader to module
+4. Poll CurrentKbootCommand until idle
+5. Reenumerate into Buspal mode
+6. `configureI2c(moduleAddress, speed=64)`
+7. `flashEraseAllUnsecure()`
+8. Read firmware from binary file
+9. `writeMemory(0, data)`
+10. `reset()`
+11. Reenumerate back to normal keyboard
+12. Send reset command to module
+13. Send idle command to module
+
+## Module I2C Addresses (Buspal)
+
+From `lib/agent/packages/uhk-common`:
+
+| Module | Address |
+|--------|---------|
+| Left Half | 0x40 |
+| Key Cluster Left | 0x41 |
+| Trackball Right | 0x42 |
+| Trackpoint Right | 0x43 |
+| Touchpad Right | 0x44 |
+
+## WriteMemory Two-Phase Protocol
+
+1. **Command phase**: Send WriteMemory with address and total size
+2. **Data phase**: Send data in 32-byte HID packets (channel 2)
+3. **Response phase**: Receive confirmation after all data sent
+
+## Timeout Handling
+
+- Response timeout: 2000 ms
+- USB read timeout: 1000 ms
+- Buspal connection retries: 30 seconds with 2-second intervals
+
+## Agent Implementation Files
+
+| File | Purpose |
+|------|---------|
+| `lib/agent/packages/kboot/src/kboot.ts` | Main KBoot class |
+| `lib/agent/packages/kboot/src/usb-peripheral.ts` | USB peripheral |
+| `lib/agent/packages/kboot/src/util/usb/encode-command-option.ts` | Command encoding |
+| `lib/agent/packages/kboot/src/util/usb/decode-command-response.ts` | Response parsing |
+| `lib/agent/packages/uhk-usb/src/uhk-operations.ts` | Firmware update workflows |
+
+## Porting Considerations
+
+### For Firmware Implementation
+
+1. **Packet Encoding**: Implement 32-byte command packet builder
+2. **Response Parsing**: Handle 0xA0/0xA3/0xA7 response tags
+3. **Data Phase**: Support multi-packet data transfer
+4. **I2C Transport**: Replace USB with I2C for module communication
+5. **State Machine**: Implement erase → write → reset sequence
+6. **Error Handling**: Handle I2C timeouts and retry logic
+
+### Memory Requirements
+
+- Command buffer: 32 bytes
+- Response buffer: 32 bytes
+- Data chunk buffer: 32 bytes
+- Firmware staging: Depends on approach (streaming vs buffered)
+
+### Key Differences from Agent
+
+1. No USB layer (direct I2C to module bootloader)
+2. No async/await (use callbacks or blocking I2C)
+3. Limited RAM (streaming approach preferred)
+4. CRC verification may be needed for I2C reliability

--- a/doc-dev/other/flashing/module-communication.md
+++ b/doc-dev/other/flashing/module-communication.md
@@ -1,0 +1,222 @@
+# Module Communication
+
+This document describes how the right half communicates with modules (key cluster, trackball, trackpad) over I2C and UART.
+
+## I2C Addresses
+
+From `shared/i2c_addresses.h`:
+
+| Module | Firmware Address | Bootloader Address |
+|--------|-----------------|-------------------|
+| Left Half | 0x08 | 0x10 |
+| Left Module | 0x18 | 0x20 |
+| Right Module | 0x28 | 0x30 |
+| Touchpad | 0x2D | 0x6D |
+
+## I2C API (UHK60)
+
+**File**: `right/src/i2c.c`
+
+```c
+// Non-blocking I2C operations
+I2cAsyncWrite(uint8_t i2cAddress, uint8_t *data, size_t dataSize);
+I2cAsyncRead(uint8_t i2cAddress, uint8_t *data, size_t dataSize);
+
+// Message-based operations with CRC16
+I2cAsyncWriteMessage(uint8_t i2cAddress, i2c_message_t *message);
+I2cAsyncReadMessage(uint8_t i2cAddress, i2c_message_t *message);
+```
+
+**Hardware Configuration**:
+- Main bus: I2C0 at 100 kHz (30 kHz for bootloader)
+- EEPROM bus: I2C1 at 1 MHz
+
+## UART API (UHK80)
+
+**File**: `device/src/keyboard/uart_modules.c`
+
+- Runs in separate kernel thread
+- Semaphore-based synchronization
+- Configurable timeout (MODULE_CONNECTION_TIMEOUT)
+
+## Slave Scheduler
+
+**File**: `right/src/slave_scheduler.c`
+
+The slave scheduler is a **round-robin, interrupt-driven I2C master** managing all module communication.
+
+### Slave Types
+
+```c
+typedef enum {
+    SlaveId_LeftKeyboardHalf,
+    SlaveId_LeftModule,
+    SlaveId_RightModule,
+    SlaveId_RightTouchpad,
+    SlaveId_RightLedDriver,
+    SlaveId_LeftLedDriver,
+    SlaveId_ModuleLeftLedDriver,
+    SlaveId_KbootDriver,
+} slave_id_t;
+```
+
+### Slave Data Structure
+
+```c
+typedef struct {
+    uint8_t perDriverId;
+    slave_init_t *init;
+    slave_update_t *update;
+    slave_disconnect_t *disconnect;
+    slave_connect_t *connect;
+    bool isConnected;
+    status_t previousStatus;
+} uhk_slave_t;
+
+extern uhk_slave_t Slaves[SLAVE_COUNT];  // 8 slaves
+```
+
+### Scheduling Flow
+
+1. `slaveSchedulerCallback()` - I2C interrupt handler
+2. Finalize previous transfer, check for errors
+3. Update connection status (connect/disconnect callbacks)
+4. Try next slave(s) in round-robin order
+5. Call `slave->update()` to get next transfer
+6. Issue scheduled I2C transfer
+
+## Module Discovery Protocol
+
+**File**: `right/src/slave_drivers/uhk_module_driver.c`
+
+Discovery phases executed in sequence:
+
+1. **Sync Request**: Validate "SYNC" string
+2. **Protocol Version**: Get 3-byte version
+3. **Firmware Version**: Get 3-byte version
+4. **Module ID**: Identify module type
+5. **Key Count**: Number of keys
+6. **Pointer Count**: Number of pointer inputs
+7. **Git Tag**: Version tag (protocol v4.2+)
+8. **Git Repo**: Repository name
+9. **Firmware Checksum**: MD5 checksum
+10. **Update Loop**: Periodic key state polling
+
+### Module State Structure
+
+```c
+typedef struct {
+    uint8_t moduleId;
+    version_t moduleProtocolVersion;
+    version_t firmwareVersion;
+    uhk_module_phase_t phase;
+    i2c_message_t rxMessage;
+    uint8_t firmwareI2cAddress;
+    uint8_t bootloaderI2cAddress;
+    uint8_t keyCount;
+    uint8_t pointerCount;
+    char gitTag[MAX_STRING_PROPERTY];
+    char firmwareChecksum[MD5_CHECKSUM];
+} uhk_module_state_t;
+```
+
+## Slave Protocol
+
+**File**: `shared/slave_protocol.h`
+
+### Message Format
+
+```c
+typedef struct {
+    uint8_t length;
+    uint16_t crc;
+    uint8_t data[SLAVE_PROTOCOL_MAX_PAYLOAD];  // max 64 bytes
+    uint8_t padding;
+} ATTR_PACKED i2c_message_t;
+```
+
+### Commands
+
+```c
+typedef enum {
+    SlaveCommand_RequestProperty = 0,
+    SlaveCommand_JumpToBootloader = 1,
+    SlaveCommand_RequestKeyStates = 2,
+    SlaveCommand_SetTestLed = 3,
+    SlaveCommand_SetLedPwmBrightness = 4,
+    SlaveCommand_ModuleSpecificCommand = 5,
+} slave_command_t;
+```
+
+### Properties
+
+```c
+typedef enum {
+    SlaveProperty_Sync = 0,
+    SlaveProperty_ModuleProtocolVersion = 1,
+    SlaveProperty_FirmwareVersion = 2,
+    SlaveProperty_ModuleId = 3,
+    SlaveProperty_KeyCount = 4,
+    SlaveProperty_PointerCount = 5,
+    SlaveProperty_GitTag = 6,
+    SlaveProperty_GitRepo = 7,
+    SlaveProperty_FirmwareChecksum = 8,
+} slave_property_t;
+```
+
+## Module Reset Mechanisms
+
+### Jump to Bootloader
+
+```c
+case UhkModulePhase_JumpToBootloader:
+    txMessage.data[0] = SlaveCommand_JumpToBootloader;
+    txMessage.length = 1;
+    res.status = tx(i2cAddress);
+    break;
+```
+
+### Trackpoint Reset
+
+```c
+void UhkModuleSlaveDriver_SendTrackpointCommand(module_specific_command_t command);
+```
+
+Commands: `ResetTrackpoint`, `RunTrackpoint`, `TrackpointSignalData`, `TrackpointSignalClock`
+
+## Connection Status Management
+
+```c
+void UhkModuleSlaveDriver_Disconnect(uint8_t uhkModuleDriverId) {
+    // Clear module state
+    // Clear key states
+    // Schedule reconnection timeout (350ms)
+}
+```
+
+## Communication Flow Diagram
+
+```
+Right Half                          Module (I2C)
+    |                                   |
+    |-- SlaveCommand_RequestProperty -->|
+    |      (SlaveProperty_Sync)         |
+    |<--------- "SYNC" response --------|
+    |                                   |
+    |-- SlaveCommand_RequestProperty -->|
+    |   (SlaveProperty_ModuleId)        |
+    |<--------- ModuleId (1 byte) ------|
+    |                                   |
+    |-- [Loop: RequestKeyStates] ------>|
+    |<--------- KeyStates + Pointer ----|
+```
+
+## Key Source Files
+
+- `right/src/slave_scheduler.c` and `.h` - Round-robin scheduler
+- `right/src/slave_drivers/uhk_module_driver.c` - Module discovery/polling
+- `right/src/slave_drivers/kboot_driver.c` - Bootloader communication
+- `right/src/i2c.c` - I2C primitives (UHK60)
+- `device/src/keyboard/uart_modules.c` - UART modules (UHK80)
+- `shared/slave_protocol.h` - Protocol definitions
+- `shared/i2c_addresses.h` - I2C address mapping

--- a/doc-dev/other/flashing/usb-communication.md
+++ b/doc-dev/other/flashing/usb-communication.md
@@ -1,0 +1,178 @@
+# USB Communication APIs
+
+This document describes the USB command infrastructure used for host-to-device communication.
+
+## USB Command Handling
+
+### Main Protocol Handler
+
+**File**: `right/src/usb_protocol_handler.c`
+
+The `UsbProtocolHandler()` function is the central dispatcher that:
+- Receives command byte from position 0 in RX buffer
+- Routes to appropriate command handler via switch statement
+- Clears RX buffer after processing
+
+### Command IDs
+
+From `right/src/usb_protocol_handler.h`:
+
+```c
+typedef enum {
+    UsbCommandId_GetDeviceProperty        = 0x00,
+    UsbCommandId_Reenumerate              = 0x01,
+    UsbCommandId_JumpToModuleBootloader   = 0x02,
+    UsbCommandId_SendKbootCommandToModule = 0x03,
+    UsbCommandId_ReadConfig               = 0x04,
+    UsbCommandId_WriteHardwareConfig      = 0x05,
+    UsbCommandId_WriteStagingUserConfig   = 0x06,
+    UsbCommandId_ApplyConfig              = 0x07,
+    UsbCommandId_LaunchStorageTransfer    = 0x08,
+    UsbCommandId_GetDeviceState           = 0x09,
+    // ... more commands up to 0x1f
+} usb_command_id_t;
+```
+
+## Buffer Specifications
+
+From `right/src/usb_interfaces/usb_interface_generic_hid.h`:
+
+```c
+#define USB_GENERIC_HID_INTERRUPT_IN_PACKET_SIZE  63
+#define USB_GENERIC_HID_INTERRUPT_OUT_PACKET_SIZE 63
+#define USB_GENERIC_HID_IN_BUFFER_LENGTH          63
+#define USB_GENERIC_HID_OUT_BUFFER_LENGTH         63
+```
+
+- **Packet size**: 63 bytes (USB interrupt endpoint)
+- **Available payload**: 62 bytes (after status code)
+
+## Buffer Access Macros
+
+From `right/src/usb_protocol_handler.h`:
+
+```c
+#define GetUsbRxBufferUint8(OFFSET)  (GetBufferUint8(GenericHidOutBuffer, OFFSET))
+#define GetUsbRxBufferUint16(OFFSET) (GetBufferUint16(GenericHidOutBuffer, OFFSET))
+#define GetUsbRxBufferUint32(OFFSET) (GetBufferUint32(GenericHidOutBuffer, OFFSET))
+
+#define SetUsbTxBufferUint8(OFFSET, VALUE)  (SetBufferUint8(GenericHidInBuffer, OFFSET, VALUE))
+#define SetUsbTxBufferUint16(OFFSET, VALUE) (SetBufferUint16(GenericHidInBuffer, OFFSET, VALUE))
+#define SetUsbTxBufferUint32(OFFSET, VALUE) (SetBufferUint32(GenericHidInBuffer, OFFSET, VALUE))
+```
+
+## Chunked Transfer Pattern
+
+Large data transfers use a 4-byte header followed by data:
+
+```
+Header (4 bytes):
+  [0] = Command ID
+  [1] = Length
+  [2] = Offset low byte
+  [3] = Offset high byte
+
+Data (up to 59 bytes):
+  [4+] = Payload
+```
+
+This allows transfers up to 64 KB using 16-bit offset addressing.
+
+## Status Codes
+
+### General Status Codes
+
+```c
+typedef enum {
+    UsbStatusCode_Success        = 0,
+    UsbStatusCode_InvalidCommand = 1,
+    UsbStatusCode_Busy           = 2,
+} usb_status_code_general_t;
+```
+
+### Command-Specific Status Codes
+
+Each command defines its own status enum. Example from read config:
+
+```c
+typedef enum {
+    UsbStatusCode_ReadConfig_InvalidConfigBufferId = 2,
+    UsbStatusCode_ReadConfig_LengthTooLarge        = 3,
+    UsbStatusCode_ReadConfig_BufferOutOfBounds     = 4,
+} usb_status_code_read_config_t;
+```
+
+## Existing Module-Related Commands
+
+### JumpToModuleBootloader (0x02)
+
+```
+Request:
+  [0] = 0x02
+  [1] = Module slot ID
+
+Response:
+  [0] = Status code
+```
+
+### SendKbootCommandToModule (0x03)
+
+```
+Request:
+  [0] = 0x03
+  [1] = K-boot command (0=idle, 1=ping, 2=reset)
+  [2] = Module I2C address (if command != idle)
+
+Response:
+  [0] = Status code
+```
+
+## Agent-Side Implementation
+
+### USB Device Wrapper
+
+**File**: `lib/agent/packages/uhk-usb/src/uhk-hid-device.ts`
+
+```typescript
+public async write(buffer: Buffer): Promise<Buffer> {
+    const device = await this.getDevice();
+    await device.write(sendData);
+    let receivedData = await device.read(1000);
+    if (receivedData[0] !== 0) {
+        throw new Error(`Response code: ${receivedData[0]}`);
+    }
+    return Buffer.from(receivedData);
+}
+```
+
+### Fragment Generation
+
+**File**: `lib/agent/packages/uhk-usb/src/util.ts`
+
+```typescript
+export function getTransferBuffers(usbCommand: UsbCommand, configBuffer: Buffer): Buffer[] {
+    const MAX_SENDING_PAYLOAD_SIZE = MAX_USB_PAYLOAD_SIZE - 4;  // 59 bytes
+    // Creates array of 63-byte buffers with header + data chunks
+}
+```
+
+## Extension Points for Firmware Upload
+
+1. **New USB Command IDs**: Reserve 0x20-0x2f for firmware operations
+2. **Chunked Transfer**: Use existing 4-byte header pattern
+3. **Flash Management**:
+   - Erase flash region command
+   - Write flash command with address/data
+   - Verify checksum command
+4. **Status Monitoring**:
+   - Query transfer progress
+   - Get remaining space
+   - Query write status
+
+## Key Source Files
+
+- `right/src/usb_protocol_handler.c` and `.h` - Main dispatcher
+- `right/src/usb_commands/` - Individual command handlers
+- `right/src/usb_interfaces/usb_interface_generic_hid.c` - HID interface
+- `shared/buffer.h` - Buffer utilities
+- `lib/agent/packages/uhk-usb/src/uhk-operations.ts` - Agent operations


### PR DESCRIPTION
## Summary

Analysis phase documentation for implementing autonomous module firmware flashing. This moves K-boot protocol from Agent to right half firmware.

**Documentation created:**
- `configuration-buffer.md` - Config buffer APIs and memory layout
- `usb-communication.md` - USB command infrastructure  
- `module-communication.md` - I2C/UART slave scheduler and module discovery
- `kboot-protocol.md` - K-boot protocol details for porting from Agent
- `README.md` - Overview and proposed implementation approach

## Key Findings

1. **Memory constraint**: Module firmware (~40-60 KB) exceeds config buffer (~32 KB)
   - Need streaming approach or UHK80 external flash

2. **K-boot protocol**: Well-documented in Agent TypeScript code
   - Command/response packet structure documented
   - Flashing state machine documented

3. **Module communication**: Slave scheduler provides I2C infrastructure
   - Round-robin scheduler already handles module communication
   - Kboot driver slot exists for bootloader communication

## Next Steps

1. Design firmware upload USB protocol
2. Port K-boot packet encoding/decoding
3. Implement flashing state machine
4. Add error handling and recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)