### PR TITLE
Fix gperf token parsing to use identifier boundaries

### DIFF
--- a/right/src/macros/core.c
+++ b/right/src/macros/core.c
@@ -251,6 +251,49 @@ void Macros_Initialize() {
     LayerStack_Reset();
 }
 
+bool Macros_AnyMacroRunning() {
+    for (uint8_t i = 0; i < MACRO_STATE_POOL_SIZE; i++) {
+        if (MacroState[i].ms.macroPlaying) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void Macros_StopAllMacros() {
+    for (uint8_t i = 0; i < MACRO_STATE_POOL_SIZE; i++) {
+        if (MacroState[i].ms.macroPlaying) {
+            // Free local scopes for this macro
+            macro_scope_state_t* ls = MacroState[i].ls;
+            while (ls != NULL && ls->slotUsed) {
+                ls->slotUsed = false;
+                if (ls->parentScopeIndex == 255) {
+                    break;
+                }
+                ls = &MacroScopeState[ls->parentScopeIndex];
+            }
+
+            // Clear macro state
+            if (MacroState[i].ms.reportsUsed) {
+                MacroState[i].ms.reportsUsed = false;
+            }
+            MacroState[i].ms.macroSleeping = false;
+            MacroState[i].ms.macroPlaying = false;
+            MacroState[i].ms.macroBroken = false;
+            MacroState[i].ms.macroScheduled = false;
+        }
+    }
+
+    // Reset scheduler state
+    Macros_SchedulerState.previousSlotIdx = 0;
+    Macros_SchedulerState.currentSlotIdx = 0;
+    Macros_SchedulerState.lastQueuedSlot = 0;
+    Macros_SchedulerState.activeSlotCount = 0;
+    Macros_SchedulerState.remainingCount = 0;
+
+    S = NULL;
+}
+
 static uint8_t currentActionCmdCount() {
     if(S->ms.currentMacroAction.type == MacroActionType_Command) {
         return S->ms.currentMacroAction.cmd.cmdCount;

--- a/right/src/macros/core.h
+++ b/right/src/macros/core.h
@@ -282,6 +282,8 @@
     uint8_t Macros_TryConsumeKeyId(parser_context_t* ctx);
     void Macros_ContinueMacro(void);
     void Macros_Initialize();
+    bool Macros_AnyMacroRunning();
+    void Macros_StopAllMacros();
     void Macros_ResetBasicKeyboardReports();
     void Macros_SignalInterrupt(void);
     void Macros_ValidateAllMacros();

--- a/right/src/str_utils.c
+++ b/right/src/str_utils.c
@@ -401,7 +401,7 @@ void ConsumeAnyToken(parser_context_t* ctx)
 struct command_entry* ConsumeGperfToken(parser_context_t* ctx)
 {
     const char* start = ctx->at;
-    while (*ctx->at > 32 && ctx->at < ctx->end) {
+    while (isIdentifierChar(*ctx->at) && ctx->at < ctx->end) {
         ctx->at++;
     }
     struct command_entry* result = command_lookup(start, ctx->at - start);

--- a/right/src/test_suite/test_suite.c
+++ b/right/src/test_suite/test_suite.c
@@ -9,6 +9,7 @@
 #include "usb_interfaces/usb_interface_basic_keyboard.h"
 #include "keymap.h"
 #include "config_manager.h"
+#include "macros/core.h"
 #include "macros/vars.h"
 #include "mouse_controller.h"
 #include "layer_stack.h"
@@ -61,6 +62,7 @@ static bool advanceToNextTest(void) {
 }
 
 static void startTest(const test_t *test, const test_module_t *module) {
+    Macros_StopAllMacros();
     ConfigManager_ResetConfiguration(false);
     LayerStack_Reset();
     if (TestSuite_Verbose) {
@@ -102,10 +104,21 @@ void TestHooks_Tick(void) {
     bool outputDone = OutputMachine_IsDone();
     bool failed = InputMachine_Failed || OutputMachine_Failed;
     bool timedOut = InputMachine_TimedOut && !outputDone;
+    bool macrosRunning = Macros_AnyMacroRunning();
+
+    // If input/output done but macros still running, wait for timeout
+    if (inputDone && outputDone && macrosRunning && !timedOut) {
+        return;
+    }
 
     if (inputDone && (outputDone || timedOut || failed)) {
         const test_t *test = getCurrentTest();
         const test_module_t *module = AllTestModules[currentModuleIndex];
+
+        // On timeout, kill all running macros
+        if (timedOut) {
+            Macros_StopAllMacros();
+        }
 
         if (failed || timedOut) {
             if (isRerunning || singleTestMode) {
@@ -172,6 +185,7 @@ void TestHooks_Tick(void) {
     return;
 
 finish:
+    Macros_StopAllMacros();
     LogU("[TEST] ----------------------\n");
     LogU("[TEST] Complete: %d passed, %d failed\n", passedCount, failedCount);
     TestHooks_Active = false;


### PR DESCRIPTION
ConsumeGperfToken was using `> 32` to find token boundaries, treating any non-whitespace as part of the token. This caused `if(1 == 1)` to be parsed as token `if(1` instead of `if`.

Now uses isIdentifierChar() to match the behavior of ConsumeToken(), correctly stopping at non-identifier chars like `(`.