### PR TITLE
Throttle report construction on slow transports.

### DIFF
--- a/right/src/hid/transport.cpp
+++ b/right/src/hid/transport.cpp
@@ -12,6 +12,7 @@ extern "C" {
 #include "key_states.h"
 #include "logger.h"
 #include "macro_events.h"
+#include "timer.h"
 #include "usb_report_updater.h"
 }
 #include "command_app.hpp"
@@ -30,6 +31,44 @@ typedef enum {
     ReportSink_BleHid,
     ReportSink_Dongle,
 } report_sink_t;
+
+// Approximate transport window intervals (ms) used by the report-construction
+// throttle. After dispatch we estimate the next free window at "now + 2 *
+// interval" (worst case: we just missed a window). The send-completion
+// callback then reduces the estimate to "now + interval".
+static constexpr uint32_t USB_REPORT_INTERVAL_MS = 1;
+static constexpr uint32_t BLE_HID_REPORT_INTERVAL_MS = 11;
+static constexpr uint32_t DONGLE_REPORT_INTERVAL_MS = 7;
+
+static uint32_t reportIntervalForSink(report_sink_t sink)
+{
+    switch (sink) {
+    case ReportSink_Usb:
+        return USB_REPORT_INTERVAL_MS;
+    case ReportSink_BleHid:
+        return BLE_HID_REPORT_INTERVAL_MS;
+    case ReportSink_Dongle:
+        return DONGLE_REPORT_INTERVAL_MS;
+    default:
+        return 0;
+    }
+}
+
+static uint32_t reportIntervalForTransport(hid_transport_t transport)
+{
+    return (transport == HID_TRANSPORT_USB) ? USB_REPORT_INTERVAL_MS : BLE_HID_REPORT_INTERVAL_MS;
+}
+
+static void noteReportDispatched(report_sink_t sink)
+{
+    UsbReportWindowEstimate = Timer_GetCurrentTime() + 2 * reportIntervalForSink(sink);
+}
+
+static void noteReportSent(hid_transport_t transport)
+{
+    UsbReportWindowEstimate = Timer_GetCurrentTime() + reportIntervalForTransport(transport);
+    EventVector_WakeMain();
+}
 
 static report_sink_t determineSink()
 {
@@ -88,19 +127,24 @@ extern "C" void Hid_TransportStateChanged(
 
 extern "C" errno_t Hid_SendKeyboardReport(const hid_keyboard_report_t *report)
 {
-    switch (determineSink()) {
+    report_sink_t sink = determineSink();
+    errno_t result;
+    switch (sink) {
     case ReportSink_Usb:
-        return keyboard_app::usb_handle().send_report(*report);
+        result = keyboard_app::usb_handle().send_report(*report);
+        break;
 #if DEVICE_IS_UHK80_RIGHT
     case ReportSink_BleHid:
-        return keyboard_app::ble_handle().send_report(*report);
+        result = keyboard_app::ble_handle().send_report(*report);
+        break;
 #endif
 #if DEVICE_IS_UHK80
     case ReportSink_Dongle:
         // TODO: propagate underlying error up the stack
         Messenger_Send2(DeviceId_Uhk_Dongle, MessageId_SyncableProperty,
             SyncablePropertyId_KeyboardReport, (const uint8_t *)report, sizeof(*report));
-        return 0;
+        result = 0;
+        break;
 #endif
     default:
 #ifdef __ZEPHYR__
@@ -108,11 +152,16 @@ extern "C" errno_t Hid_SendKeyboardReport(const hid_keyboard_report_t *report)
 #endif
         return -EHOSTUNREACH;
     }
+    if (result == 0) {
+        noteReportDispatched(sink);
+    }
+    return result;
 }
 
 extern "C" void Hid_KeyboardReportSentCallback(hid_transport_t transport)
 {
     UsbReportUpdateSemaphore &= ~UsbReportUpdate_Keyboard;
+    noteReportSent(transport);
 #if DEVICE_IS_UHK_DONGLE
     Dongle_SignalUsbReportSent();
 #endif
@@ -120,19 +169,24 @@ extern "C" void Hid_KeyboardReportSentCallback(hid_transport_t transport)
 
 extern "C" errno_t Hid_SendMouseReport(const hid_mouse_report_t *report)
 {
-    switch (determineSink()) {
+    report_sink_t sink = determineSink();
+    errno_t result;
+    switch (sink) {
     case ReportSink_Usb:
-        return mouse_app::usb_handle().send_report(*report);
+        result = mouse_app::usb_handle().send_report(*report);
+        break;
 #if DEVICE_IS_UHK80_RIGHT
     case ReportSink_BleHid:
-        return mouse_app::ble_handle().send_report(*report);
+        result = mouse_app::ble_handle().send_report(*report);
+        break;
 #endif
 #if DEVICE_IS_UHK80
     case ReportSink_Dongle:
         // TODO: propagate underlying error up the stack
         Messenger_Send2(DeviceId_Uhk_Dongle, MessageId_SyncableProperty,
             SyncablePropertyId_MouseReport, (const uint8_t *)report, sizeof(*report));
-        return 0;
+        result = 0;
+        break;
 #endif
     default:
 #ifdef __ZEPHYR__
@@ -140,11 +194,16 @@ extern "C" errno_t Hid_SendMouseReport(const hid_mouse_report_t *report)
 #endif
         return -EHOSTUNREACH;
     }
+    if (result == 0) {
+        noteReportDispatched(sink);
+    }
+    return result;
 }
 
 extern "C" void Hid_MouseReportSentCallback(hid_transport_t transport)
 {
     UsbReportUpdateSemaphore &= ~UsbReportUpdate_Mouse;
+    noteReportSent(transport);
 #if DEVICE_IS_UHK_DONGLE
     Dongle_SignalUsbReportSent();
 #endif
@@ -152,19 +211,24 @@ extern "C" void Hid_MouseReportSentCallback(hid_transport_t transport)
 
 extern "C" errno_t Hid_SendControlsReport(const hid_controls_report_t *report)
 {
-    switch (determineSink()) {
+    report_sink_t sink = determineSink();
+    errno_t result;
+    switch (sink) {
     case ReportSink_Usb:
-        return controls_app::usb_handle().send_report(*report);
+        result = controls_app::usb_handle().send_report(*report);
+        break;
 #if DEVICE_IS_UHK80_RIGHT
     case ReportSink_BleHid:
-        return controls_app::ble_handle().send_report(*report);
+        result = controls_app::ble_handle().send_report(*report);
+        break;
 #endif
 #if DEVICE_IS_UHK80
     case ReportSink_Dongle:
         // TODO: propagate underlying error up the stack
         Messenger_Send2(DeviceId_Uhk_Dongle, MessageId_SyncableProperty,
             SyncablePropertyId_ControlsReport, (const uint8_t *)report, sizeof(*report));
-        return 0;
+        result = 0;
+        break;
 #endif
     default:
 #ifdef __ZEPHYR__
@@ -172,11 +236,16 @@ extern "C" errno_t Hid_SendControlsReport(const hid_controls_report_t *report)
 #endif
         return -EHOSTUNREACH;
     }
+    if (result == 0) {
+        noteReportDispatched(sink);
+    }
+    return result;
 }
 
 extern "C" void Hid_ControlsReportSentCallback(hid_transport_t transport)
 {
     UsbReportUpdateSemaphore &= ~UsbReportUpdate_Controls;
+    noteReportSent(transport);
 #if DEVICE_IS_UHK_DONGLE
     Dongle_SignalUsbReportSent();
 #endif

--- a/right/src/usb_report_updater.c
+++ b/right/src/usb_report_updater.c
@@ -72,6 +72,13 @@ static key_action_cached_t actionCache[SLOT_COUNT][MAX_KEY_COUNT_PER_MODULE];
 
 uint32_t UsbReportUpdater_LastActivityTime;
 
+uint32_t UsbReportWindowEstimate = 0;
+
+// Maximum lookahead used by the throttle check: if the estimated next
+// transport window is more than this many milliseconds in the future, we
+// postpone report construction so that further keystroke state can accumulate.
+#define USB_REPORT_WINDOW_LOOKAHEAD_MS 4
+
 volatile uint8_t UsbReportUpdateSemaphore = 0;
 
 // Modifiers can be applied as one of the following classes
@@ -1009,14 +1016,31 @@ static void sendActiveReports(bool resending) {
 
 static bool blockedByKeystrokeDelay() {
     static uint32_t postponedMasks = 0;
-    if (Timer_GetCurrentTime() < lastBasicReportTime + Cfg.KeystrokeDelay) {
+    uint32_t currentTime = Timer_GetCurrentTime();
+    uint32_t blockedUntil = 0;
+    bool blocked = false;
+    if (currentTime < lastBasicReportTime + Cfg.KeystrokeDelay) {
+        blockedUntil = lastBasicReportTime + Cfg.KeystrokeDelay;
+        blocked = true;
+    }
+    // Throttle on slow transports (BLE HID, dongle): if the estimated next
+    // transport window is further than the lookahead in the future, postpone
+    // report construction so that further keystroke state can accumulate.
+    if ((int32_t)(UsbReportWindowEstimate - currentTime) > USB_REPORT_WINDOW_LOOKAHEAD_MS) {
+        uint32_t throttleUntil = UsbReportWindowEstimate - USB_REPORT_WINDOW_LOOKAHEAD_MS;
+        if (!blocked || throttleUntil > blockedUntil) {
+            blockedUntil = throttleUntil;
+        }
+        blocked = true;
+    }
+    if (blocked) {
         DISABLE_IRQ();
         postponedMasks |= EventScheduler_Vector & EventVector_MainTriggers;
         EventScheduler_Vector = (EventScheduler_Vector & ~EventVector_MainTriggers) | EventVector_KeystrokeDelayPostponing;
         ENABLE_IRQ();
 
         // Make sure to wake up postponer so that it can process the events.
-        EventScheduler_Reschedule(lastBasicReportTime + Cfg.KeystrokeDelay, EventSchedulerEvent_Postponer, "keystroke delay");
+        EventScheduler_Reschedule(blockedUntil, EventSchedulerEvent_Postponer, "report throttle");
 
         justPreprocessInput();
         return true;

--- a/right/src/usb_report_updater.h
+++ b/right/src/usb_report_updater.h
@@ -52,6 +52,11 @@
     extern usb_keyboard_reports_t NativeKeyboardReports;
     extern uint32_t LastUsbGetKeyboardStateRequestTimestamp;
     extern uint32_t UsbReportUpdater_LastActivityTime;
+    // Estimated absolute time (Timer_GetCurrentTime() units, ms) at which the
+    // transport will be ready to accept the next report. Used to throttle
+    // report construction when the transport is slow (BLE HID, dongle).
+    // Bumped forward on dispatch and reduced from the send-completion callback.
+    extern uint32_t UsbReportWindowEstimate;
 
 // Functions:
 


### PR DESCRIPTION
  Summary of the re-implementation

  - right/src/usb_report_updater.{c,h} — added the UsbReportWindowEstimate global and the USB_REPORT_WINDOW_LOOKAHEAD_MS = 4 constant. blockedByKeystrokeDelay() now also
  blocks when the estimate is more than 4 ms in the future, picks the later of the keystroke-delay and throttle deadlines, and reschedules the postponer accordingly.
  - right/src/hid/transport.cpp — added per-transport interval constants (USB 1 ms, BLE HID 11 ms, Dongle 7 ms) plus two helpers:
    - noteReportDispatched(sink) — sets estimate to now + 2 * interval (worst case) right after a successful dispatch in Hid_Send{Keyboard,Mouse,Controls}Report.
    - noteReportSent(transport) — reduces estimate to now + interval from Hid_{Keyboard,Mouse,Controls}ReportSentCallback and wakes the main loop so the throttle releases
  promptly.
    - The three send functions were lightly refactored (switch writes to a local result instead of returning early) so the dispatch hook lives in one place at the bottom.
  - For the dongle path the right side has no direct send-completion callback, so the estimate naturally decays from now + 14 ms toward the lookahead window — slightly more
  conservative than BLE/USB but still self-recovering.
  - Verified by building uhk-80-right via ./build.sh right make. Both transport.cpp.obj and usb_report_updater.c.obj were rebuilt.

