### PR TITLE
Validate smart macro event names

### DIFF
--- a/right/src/macro_events.c
+++ b/right/src/macro_events.c
@@ -5,6 +5,7 @@
 #include "macro_events.h"
 #include "config_parser/parse_macro.h"
 #include "macros/core.h"
+#include "macros/status_buffer.h"
 #include "keymap.h"
 #include "led_display.h"
 #include "debug.h"
@@ -255,4 +256,96 @@ void MacroEvent_ProcessJoinSplitEvents(merge_sensor_state_t currentlyJoined)
         }
         previousEventMacroSlot = 255;
     }
+}
+
+static void validateLayerToken(const char* tokStart, const char* end) {
+    Macros_ConsumeLayerId(&(parser_context_t){.at = tokStart, .end = end});
+}
+
+static void validateOneEventName(const char* name, const char* nameEnd)
+{
+    const char* arg1 = NextTok(name, nameEnd);
+
+    bool noArgs = TokenMatches(name, nameEnd, "$onInit")
+        || TokenMatches(name, nameEnd, "$onCapsLockStateChange")
+        || TokenMatches(name, nameEnd, "$onNumLockStateChange")
+        || TokenMatches(name, nameEnd, "$onScrollLockStateChange")
+        || TokenMatches(name, nameEnd, "$onJoin")
+        || TokenMatches(name, nameEnd, "$onSplit")
+        || TokenMatches(name, nameEnd, "$onError");
+    if (noArgs) {
+        if (arg1 != nameEnd) {
+            Macros_ReportError("Macro event takes no arguments:", name, nameEnd);
+        }
+        return;
+    }
+
+    if (TokenMatches(name, nameEnd, "$onKeymapChange")) {
+        if (arg1 == nameEnd) {
+            Macros_ReportError("$onKeymapChange requires <keymap-abbreviation> or 'any':", name, nameEnd);
+            return;
+        }
+        if (NextTok(arg1, nameEnd) != nameEnd) {
+            Macros_ReportError("$onKeymapChange takes a single argument:", name, nameEnd);
+        }
+        return;
+    }
+
+    if (TokenMatches(name, nameEnd, "$onKeymapLayerChange")) {
+        if (arg1 == nameEnd) {
+            Macros_ReportError("$onKeymapLayerChange requires <keymap-abbreviation> <layer>:", name, nameEnd);
+            return;
+        }
+        const char* arg2 = NextTok(arg1, nameEnd);
+        if (arg2 == nameEnd) {
+            Macros_ReportError("$onKeymapLayerChange requires a layer argument:", name, nameEnd);
+            return;
+        }
+        validateLayerToken(arg2, nameEnd);
+        if (Macros_ParserError) {
+            return;
+        }
+        if (NextTok(arg2, nameEnd) != nameEnd) {
+            Macros_ReportError("$onKeymapLayerChange takes exactly two arguments:", name, nameEnd);
+        }
+        return;
+    }
+
+    if (TokenMatches(name, nameEnd, "$onLayerChange")) {
+        if (arg1 == nameEnd) {
+            Macros_ReportError("$onLayerChange requires 'any' or a layer:", name, nameEnd);
+            return;
+        }
+        if (!TokenMatches(arg1, nameEnd, "any")) {
+            validateLayerToken(arg1, nameEnd);
+            if (Macros_ParserError) {
+                return;
+            }
+        }
+        if (NextTok(arg1, nameEnd) != nameEnd) {
+            Macros_ReportError("$onLayerChange takes a single argument:", name, nameEnd);
+        }
+        return;
+    }
+
+    Macros_ReportError("Unknown smart macro event:", name, nameEnd);
+}
+
+void MacroEvent_ValidateEventNames(void)
+{
+    bool oldParserStatus = Macros_ParserError;
+
+    for (int i = 0; i < AllMacrosCount; i++) {
+        const char *thisName, *thisNameEnd;
+        FindMacroName(&AllMacros[i], &thisName, &thisNameEnd);
+
+        if (thisName == thisNameEnd || *thisName != '$') {
+            continue;
+        }
+
+        Macros_ParserError = false;
+        validateOneEventName(thisName, thisNameEnd);
+    }
+
+    Macros_ParserError = oldParserStatus;
 }

--- a/right/src/macro_events.h
+++ b/right/src/macro_events.h
@@ -36,5 +36,6 @@
     void MacroEvent_ProcessStateKeyEvents();
     void MacroEvent_ProcessJoinSplitEvents(merge_sensor_state_t currentlyJoined);
     void MacroEvent_TriggerGenericEvent(generic_macro_event_t eventId);
+    void MacroEvent_ValidateEventNames(void);
 
 #endif

--- a/right/src/macros/core.c
+++ b/right/src/macros/core.c
@@ -2,6 +2,7 @@
 #include "config_parser/parse_macro.h"
 #include "debug.h"
 #include "event_scheduler.h"
+#include "macro_events.h"
 #include "key_history.h"
 #include "keymap.h"
 #include "layer_stack.h"
@@ -599,6 +600,8 @@ void Macros_ValidateAllMacros()
     for (uint8_t macroIndex = 0; macroIndex < AllMacrosCount; macroIndex++) {
         Macros_ValidateMacro(macroIndex, 0, 255, 255, 255, 255);
     }
+
+    MacroEvent_ValidateEventNames();
 
     uint32_t t2 = Timer_GetCurrentTime();
     LogU("Validation completed in %d ms!\n", t2 - t1);


### PR DESCRIPTION
- **Add K-boot flashing analysis documentation**
- **Add firmware upload proposal with current config flow**
- **Add missing secondary role settings to user config (version 14)**
- **ParseConfig: use explicit serialization enums for secondary roles.**
- **Kboot: Add an overview implementation plan.**
- **reword.**
- **Implement new usb flashing Api.**
- **Kboot: Enable kboot driver on Zephyr and add shell command.**
- **Implement a poc of kboot-module communication.**
- **nrf: update sysbuild presets workaround with upstream**
- **move c2usb interfacing code under the right sources**
- **split vscode to two workspaces, one for nrfsdk and one for mcuxsdk development**
- **right: integrate c2usb into the build, without any effect**
- **tooling configuration update**
- **major refactoring of UHK60 right USB interface**
- **Fix PID in west_agent.py**
- **Handle uhk60 debug builds in build.sh.**
- **Add vscode build variants.**
- **Log and reconnect on repeated report send fails.**
- **Check hogp health. Disconnect if it doesn't look good.**
- **release with debug info**
- **scripts: add west vscode command**
- **Fix healthcheck compilation.**
- **Use system build environment in build.sh.**
- **DOCS: add uhk80 vscode debugging stuff.**
- **agent doesn't support report ID on UHK60**
- **uhk60: make debugging possible with bootloader+app flashing**
- **c2usb fixes**
- **ci: use latest zephyr SDK**
- **uhk60: restore suspend and resume handling**
- **assume high resolution scrolling when enumerated on Windows**
- **uhk60: fix buspal USB**
- **set manifest path at workspace loading**
- **c2usb integration update**
- **Revert c2usb input interceptor removal -> fix pairing screen.**
- **Fix serial number length. And consequent memory corruption.**
- **Implement proper retry handling on dongle.**
- **Revert "Implement proper retry handling on dongle."**
- **Block/retry for dongle usb transports.**
- **Fix shell log filtering.**
- **Remove some aggressive reconnection attempts.**
- **fix debugging with west vscode generated config**
- **c2usb zephyr USB handling update**
- **don't advertise NUS by name, as it's not used at scanning**
- **Hid transport: Adjust error logging.**
- **Update dongle scroll multipliers.**
- **fixup! c2usb zephyr USB handling update**
- **fix hogp report sending getting stuck in busy error**
- **Fix input processing during usb resend periods.**
- **Unselect host on second tap.**
- **Update changelog and bump versions.**
- **Send battery level notifications only if the host is awake.**
- **Add regression test.**
- **Fix the Layers/layer_hold_replace_layer regression.**
- **Fix some warnings.**
- **Instrument BLE HID report dispatch→sent latency.**
- **Throttle report construction on slow transports.**
- **Wire the report throttle to actual ble hid interval**
- **Throttling: make it work for dongle too.**
- **Throttling: refactor testing code away.**
- **Remove surplus comment.**
- **Implement kboot write.**
- **Some comments.**
- **DOCS: add a link to the agent smart macro pane.**
- **DOCS: readme doc updates.**
- **ci: bump JamesIves/github-pages-deploy-action 4.0.0 => 4.8.0**
- **ci: bump JamesIves/github-pages-deploy-action 4.0.0 => 4.8.0 (#1530)**
- **ci: bump actions to the latest major**
- **ci: bump actions to the latest major (#1531)**
- **Add exact send report traces.**
- **Add tests for macro sticky keys.**
- **Fix premature reset of macro sticky mods.**
- **Disable thread performance stats.**
- **Prevent github ci from building from "nonexistent" commit hashes.**
- **Fix errors.**
- **Update CHANGELOG and bump versions.**
- **Bump Agent reference.**
- **ci: use github.ref instead of github.sha to use git tag when releasing new version (#1535)**
- **ci: add missing v to the JamesIves/github-pages-deploy-action version (#1537)**
- **Validate smart macro event names**
