### PR TITLE
Disable left-side BLE link to right when UART link is healthy

### DIFF
--- a/device/src/bt_manager.c
+++ b/device/src/bt_manager.c
@@ -108,6 +108,21 @@ void BtManager_StopBt() {
     LOG_INF("OOB: Bluetooth stopped");
 }
 
+void BtManager_CheckLeftBleVsUart() {
+    if (DEVICE_IS_UHK80_LEFT) {
+        bool uartReady = Connections_IsReady(ConnectionId_UartRight);
+
+        if (uartReady) {
+            bool nusConnected = Peers[PeerIdRight].conn != NULL;
+            if (nusConnected) {
+                LOG_INF("Left: UART healthy and NUS up — disconnecting NUS to right");
+                bt_conn_disconnect(Peers[PeerIdRight].conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+            }
+        } else {
+            BtManager_StartScanningAndAdvertisingAsync(false, "Left UART not ready — resume BLE");
+        }
+    }
+}
 
 void BtManager_StartScanningAndAdvertisingAsync(bool wasAggresive, const char* eventLabel) {
     BT_TRACE_AND_ASSERT("bm4");
@@ -168,7 +183,7 @@ void BtManager_StartScanningAndAdvertising() {
         }
     }
 
-    bool leftShouldAdvertise = DEVICE_IS_UHK80_LEFT && Peers[PeerIdRight].conn == NULL;
+    bool leftShouldAdvertise = DEVICE_IS_UHK80_LEFT && Peers[PeerIdRight].conn == NULL && !DeviceState_IsTargetConnected(ConnectionTarget_Right);
     bool rightShouldAdvertise = DEVICE_IS_UHK80_RIGHT && true;
     bool shouldAdvertise = leftShouldAdvertise || rightShouldAdvertise;
 

--- a/device/src/bt_manager.h
+++ b/device/src/bt_manager.h
@@ -27,4 +27,6 @@
     void BtManager_StartScanningAndAdvertisingAsync(bool wasAggresive, const char* eventLabel);
     void BtManager_EnterMode(pairing_mode_t mode, bool toggle);
 
+    void BtManager_CheckLeftBleVsUart();
+
 #endif // __BT_MANAGER_H__

--- a/device/src/keyboard/uart_bridge.c
+++ b/device/src/keyboard/uart_bridge.c
@@ -5,6 +5,7 @@
 #include "messenger.h"
 #include "messenger_queue.h"
 #include "device.h"
+#include "bt_manager.h"
 #include "debug.h"
 #include "connections.h"
 #include "resend.h"
@@ -210,6 +211,13 @@ static void updateConnectionState(uart_state_t *uartState) {
         Connections_SetState(connectionId, newIsConnected ? ConnectionState_Ready : ConnectionState_Disconnected);
         k_sem_give(&uartState->txBufferBusy);
         k_sem_give(&uartState->core.txControlBusy);
+        if (DEVICE_IS_UHK80_LEFT) {
+            if (newIsConnected) {
+                EventScheduler_Reschedule( Timer_GetCurrentTime() + 10000, EventSchedulerEvent_CheckLeftBleVsUart, "Left UART up — schedule BLE vs UART check");
+            } else {
+                BtManager_CheckLeftBleVsUart();
+            }
+        }
     }
 }
 

--- a/right/src/event_scheduler.c
+++ b/right/src/event_scheduler.c
@@ -246,6 +246,11 @@ static void processEvt(event_scheduler_event_t evt)
             BtConn_KickHid();
 #endif
             break;
+        case EventSchedulerEvent_CheckLeftBleVsUart:
+#if DEVICE_IS_UHK80_LEFT
+            BtManager_CheckLeftBleVsUart();
+#endif
+            break;
         default:
             return;
     }

--- a/right/src/event_scheduler.h
+++ b/right/src/event_scheduler.h
@@ -49,6 +49,7 @@
         EventSchedulerEvent_UnselectHostConnection,
         EventSchedulerEvent_OneShotTimeout,
         EventSchedulerEvent_KickHid,
+        EventSchedulerEvent_CheckLeftBleVsUart,
         EventSchedulerEvent_Count
     } event_scheduler_event_t;
 


### PR DESCRIPTION
When the left half's UART link to right comes up, wait 10s. If both NUS and UART links are alive, disconnect NUS and suppress directed-NUS advertising while UART stays healthy. Resume advertising when UART goes down.